### PR TITLE
fix: add swagger endpoint to test connection url

### DIFF
--- a/charts/sdfactory/templates/tests/test-connection.yaml
+++ b/charts/sdfactory/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "sdfactory.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "sdfactory.fullname" . }}:{{ .Values.service.port }}/swagger-ui/index.html']
   restartPolicy: Never


### PR DESCRIPTION
As there is nothing in / path, the application responds with 404 so the helm test will fail. Adding the swagger endpoint to the url should solve the test case as it would respond with a 200.