### PR TITLE
keycloak manager fix for tests; update DEPENDENCIES

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,8 +1,8 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.11, EPL-1.0 OR LGPL-2.1-only, approved, #3435
 maven/mavencentral/ch.qos.logback/logback-core/1.4.11, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.danubetech/key-formats-java/1.6.0, None, restricted, #10950
-maven/mavencentral/com.danubetech/verifiable-credentials-java/1.1.0, None, restricted, #10953
+maven/mavencentral/com.danubetech/key-formats-java/1.6.0, Apache-2.0, approved, #10950
+maven/mavencentral/com.danubetech/verifiable-credentials-java/1.1.0, Apache-2.0, approved, #10953
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.2, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.2, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2, Apache-2.0, approved, #7934
@@ -28,7 +28,7 @@ maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/decentralized-identity/jsonld-common-java/1.1.0, Apache-2.0, approved, #10954
-maven/mavencentral/info.weboftrust/ld-signatures-java/1.2.0, None, restricted, #10951
+maven/mavencentral/info.weboftrust/ld-signatures-java/1.2.0, Apache-2.0, approved, #10951
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
 maven/mavencentral/io.github.erdtman/java-json-canonicalization/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.openfeign.form/feign-form-spring/3.8.0, Apache-2.0, approved, clearlydefined
@@ -79,7 +79,7 @@ maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.4, Apac
 maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.1.4, Apache-2.0, approved, #9348
 maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.1.4, Apache-2.0, approved, #9342
 maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.4, Apache-2.0, approved, #9341
-maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.1.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.1.4, Apache-2.0, approved, #11406
 maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.1.4, Apache-2.0, approved, #9344
 maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.4, Apache-2.0, approved, #9338
 maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.4, Apache-2.0, approved, #9336


### PR DESCRIPTION
if any of keycloak parameter is missed for a feign service it results in an exeption when token is requested. This fix disables retrieving the token if any parameter is missed.
DEPENDENCIES file is updated. No restrictions are found in the libraries