### PR TITLE
fix: Security fix for bouncycastle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
- - Trivy security fix for bouncycastle
  
-## [2.1.9] - 2023-11-24
+ 
+## [2.1.8] - 2023-11-27
 
 ### Changed
+- Security fix for bouncycastle which can have DoS issue
 - Updated base image
 - Updated workflow for helm lint
 - helm upgrade workflow fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Updated base image
 - Updated workflow for helm lint
 - helm upgrade workflow fix
- 
-## [2.1.8] - 2023-10-17
-
-### Changed
- - Refactoring SD Factory
+- Refactoring SD Factory
 
 ## [2.1.7] - 2023-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+ - Trivy security fix for bouncycastle
+ 
+## [2.1.9] - 2023-11-24
+
+### Changed
 - Updated base image
 - Updated workflow for helm lint
 - helm upgrade workflow fix
+ 
+## [2.1.8] - 2023-10-17
+
+### Changed
+ - Refactoring SD Factory
 
 ## [2.1.7] - 2023-10-05
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -59,7 +59,7 @@ maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, EPL-1.0, approved, tools.as
 maven/mavencentral/org.bitcoinj/bitcoinj-core/0.16.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.70, MIT, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.70, MIT, approved, #1712
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.71, MIT, approved, #3475
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk15on/1.70, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
 maven/mavencentral/org.glassfish/jakarta.json/2.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ further processing.
 
 ```shell
 Software version: 2.1.8
-Helm Chart version: 2.1.9
+Helm Chart version: 2.1.10
 
 ```
 

--- a/charts/sdfactory/Chart.yaml
+++ b/charts/sdfactory/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "2.1.9"
+version: "2.2.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sdfactory/Chart.yaml
+++ b/charts/sdfactory/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "2.2.0"
+version: "2.1.10"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sdfactory/README.md
+++ b/charts/sdfactory/README.md
@@ -1,6 +1,6 @@
 # sdfactory
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.8](https://img.shields.io/badge/AppVersion-2.1.8-informational?style=flat-square)
+![Version: 2.1.10](https://img.shields.io/badge/Version-2.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.8](https://img.shields.io/badge/AppVersion-2.1.8-informational?style=flat-square)
 
 Helm Charts for SD Factory application. Self-Description Factory component is responsible for the creation of Self Descriptions.
 

--- a/charts/sdfactory/README.md
+++ b/charts/sdfactory/README.md
@@ -1,6 +1,6 @@
 # sdfactory
 
-![Version: 2.1.9](https://img.shields.io/badge/Version-2.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.8](https://img.shields.io/badge/AppVersion-2.1.8-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.8](https://img.shields.io/badge/AppVersion-2.1.8-informational?style=flat-square)
 
 Helm Charts for SD Factory application. Self-Description Factory component is responsible for the creation of Self Descriptions.
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             <version>1.70</version>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.77</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-javalite</artifactId>
             <version>3.22.3</version>


### PR DESCRIPTION
- To fix the below issue:
Bouncy Castle for Java before 1.73 contains a potential Denial of Service (DoS) issue within the Bouncy Castle org.bouncycastle.openssl.PEMParser class. This class parses OpenSSL PEM encoded streams containing X.509 certificates, PKCS8 encoded keys, and PKCS7 objects. Parsing a file that has crafted ASN.1 data through the PEMParser causes an OutOfMemoryError, which can enable a denial of service attack.