### PR TITLE
chore: Updated kindest node version tag

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,6 +1,6 @@
 #################################################################################
-# Copyright (c) 2022,2023 T-Systems International GmbH
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 T-Systems International GmbH
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +18,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-
 name: Lint and Test Chart
 
 on:
@@ -34,7 +33,7 @@ on:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
         # k8s version from 3.1 release
-        default: 'kindest/node:v1.24.6'
+        default: 'kindest/node:v1.27.13'
         required: false
         type: string
       upgrade_from:
@@ -57,7 +56,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           version: v0.19.0
-          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.24.6' }}
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.13' }}
       - name: Build image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
- This PR is to upgrade the kindest/node version tag to v1.27.13
- Resolves #143 