### PR TITLE
fix(helm): change ingress to work without tls enabled

### DIFF
--- a/charts/sdfactory/Chart.yaml
+++ b/charts/sdfactory/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "2.1.18"
+version: "2.1.19"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sdfactory/README.md
+++ b/charts/sdfactory/README.md
@@ -1,6 +1,6 @@
 # sdfactory
 
-![Version: 2.1.18](https://img.shields.io/badge/Version-2.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.12](https://img.shields.io/badge/AppVersion-2.1.12-informational?style=flat-square)
+![Version: 2.1.19](https://img.shields.io/badge/Version-2.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.12](https://img.shields.io/badge/AppVersion-2.1.12-informational?style=flat-square)
 
 Helm Charts for SD Factory application. Self-Description Factory component is responsible for the creation of Self Descriptions.
 
@@ -28,8 +28,7 @@ Helm Charts for SD Factory application. Self-Description Factory component is re
 | ingress.hosts[0] | object | `{"host":"","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}` | Host of the application on which application runs |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` | ImplementationSpecific path type matching is up to the IngressClass. Implementations can treat this as a separate pathType or treat it identically to Prefix or Exact path types. |
 | ingress.issuer | string | `"letsencrypt-prod"` | Kubernetes resources that represent certificate authorities that are able to generate signed certificates by honoring certificate signing requests. |
-| ingress.tls[0].hosts | string | `""` |  |
-| ingress.tls[0].tlsName | string | `""` |  |
+| ingress.tls | list | `[]` | Ingress TLS configuration |
 | livenessProbe.initialDelaySeconds | int | `10` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | nameOverride | string | `""` |  |

--- a/charts/sdfactory/values.yaml
+++ b/charts/sdfactory/values.yaml
@@ -112,9 +112,10 @@ ingress:
         - path: /
     # -- ImplementationSpecific path type matching is up to the IngressClass. Implementations can treat this as a separate pathType or treat it identically to Prefix or Exact path types.
           pathType: ImplementationSpecific
-  tls:
-    - tlsName: ""
-      hosts: ""
+  # -- Ingress TLS configuration
+  tls: []
+    # - tlsName: ""
+    #   hosts: ""
 
 resources:
   limits:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

fix ingress to work without tls enabled

I noticed that it isn't possible to enable the ingress without TLS enabled as well and that is quite an annoyance if one wants to use the sd-factory in a local testing setup (umbrella), this is due to the following validation: https://github.com/eclipse-tractusx/sd-factory/blob/sdfactory-2.1.18/charts/sdfactory/templates/ingress.yaml#L46

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
