### PR TITLE
chore(deployment): enable readOnlyRootFilesystem

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -61,7 +61,7 @@ maven/mavencentral/net.minidev/json-smart/2.5.0, Apache-2.0, approved, clearlyde
 maven/mavencentral/org.apache.commons/commons-lang3/3.13.0, Apache-2.0, approved, #9820
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.21.1, Apache-2.0 AND (Apache-2.0 AND LGPL-2.0-or-later), approved, #11079
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.21.1, Apache-2.0, approved, #15262
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.19, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.19, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0 WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.19, Apache-2.0, approved, #6997
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.19, Apache-2.0, approved, #7920
 maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.19, Apache-2.0, approved, #8196

--- a/charts/sdfactory/templates/deployment.yaml
+++ b/charts/sdfactory/templates/deployment.yaml
@@ -107,3 +107,9 @@ spec:
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp

--- a/charts/sdfactory/values.yaml
+++ b/charts/sdfactory/values.yaml
@@ -56,7 +56,7 @@ securityContext:
     drop:
       - ALL
   allowPrivilegeEscalation: false
-  # readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
   runAsGroup: 1000


### PR DESCRIPTION
## Why

1. This resolves KSV014 from trivy.
2. Is also required by guideline: https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-07/

## Description
Activate readOnlyRootFilesystem setting in helm values.
Mount temporary directory to allow writes.

Fixes: #189

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
