### PR TITLE
fix: tomcat upgrade

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -56,10 +56,10 @@ maven/mavencentral/net.minidev/json-smart/2.5.2, Apache-2.0, approved, #19431
 maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.23.1, Apache-2.0, approved, #13368
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.23.1, Apache-2.0, approved, #15121
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.44, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.44, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.44, Apache-2.0, approved, #7920
-maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.44, Apache-2.0, approved, #8196
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.45, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.45, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.45, Apache-2.0, approved, #7920
+maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.45, Apache-2.0, approved, #8196
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.2, Apache-2.0, approved, #14178

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <resource.delimiter>^</resource.delimiter>
         <spring-cloud.version>4.1.3</spring-cloud.version>
         <dash-tool.version>1.0.3-SNAPSHOT</dash-tool.version>
-        <tomcat.version>10.1.44</tomcat.version>
+        <tomcat.version>10.1.45</tomcat.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
- Fix security vulenrability by upgading tomcat emberd core to 10.1.45

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
